### PR TITLE
fix: storybook images

### DIFF
--- a/portfolio/components/ImageSafe.vue
+++ b/portfolio/components/ImageSafe.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <nuxt-img
+      v-if="server"
+      :class="class_"
+      :src="src"
+      :width="width"
+      :height="height"
+      :alt="alt"
+    />
+    <img
+      v-else
+      :class="class_"
+      :src="src"
+      :width="width"
+      :height="height"
+      :alt="alt"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  data() {
+    return {
+      server: process.server,
+    }
+  },
+  props: {
+    class_: { type: String, default: '' },
+    src: { type: String, default: '' },
+    width: { type: String, default: '' },
+    height: { type: String, default: '' },
+    alt: { type: String, default: '' },
+  },
+}
+</script>

--- a/portfolio/components/home/hackathon/HackathonCard.vue
+++ b/portfolio/components/home/hackathon/HackathonCard.vue
@@ -5,7 +5,7 @@
   >
     <div class="flex flex-col md:flex-row">
       <div class="overflow-hidden">
-        <nuxt-img
+        <image-safe
           class="object-cover h-48 md:h-64 xl:h-48 w-full md:w-96"
           :src="image"
           width="640"

--- a/portfolio/components/home/hero/HeroHeading.vue
+++ b/portfolio/components/home/hero/HeroHeading.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col text-center">
     <div class="mx-auto">
-      <nuxt-img
+      <image-safe
         class="h-48 sm:h-64 w-48 sm:w-64 rounded-full shadow ring-2 sm:ring-4 ring-gray-200 bg-gray-200 overflow-hidden"
         src="/images/square.png"
         width="256"

--- a/portfolio/components/home/university/University.vue
+++ b/portfolio/components/home/university/University.vue
@@ -7,7 +7,7 @@
       <p class="text-xl text-gray-100 mt-3 sm:mt-5">
         BSc (Hons) Computer Science
       </p>
-      <nuxt-img
+      <image-safe
         class="h-48 sm:h-64 object-cover mt-3 rounded-lg"
         src="/images/hackathon-group.jpg"
       />
@@ -76,7 +76,7 @@
         </li>
       </ul>
       <p class="text-xl text-gray-100 mt-5 sm:mt-8">Exeter Computing Society</p>
-      <nuxt-img
+      <image-safe
         class="h-48 sm:h-64 object-cover mt-3 rounded-lg"
         src="/images/computing-society.jpg"
       />

--- a/portfolio/components/navbar/NavbarLogo.vue
+++ b/portfolio/components/navbar/NavbarLogo.vue
@@ -3,7 +3,7 @@
     to="/"
     class="flex items-center space-x-3 text-gray-50 hover:text-gray-400 duration-100"
   >
-    <nuxt-img
+    <image-safe
       class="w-8"
       src="/images/logo.png"
       width="32"

--- a/portfolio/layouts/default.vue
+++ b/portfolio/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="absolute h-full">
-      <nuxt-img
+      <image-safe
         class="top-0"
         src="/images/bg.svg"
         width="1920"


### PR DESCRIPTION
This pull request adds:
- Use `<nuxt-img>` component only in server-side rendering
- Use standard `<img>` otherwise

A slightly ugly solution, but it means that Storybook uses static assets instead of looking inside `_ipx/`, which is only made available during SSR (i.e. not after a build)

---

Issue raised at:
- https://github.com/nuxt/image/issues/590
