### PR TITLE
fix: background vector width

### DIFF
--- a/portfolio/layouts/default.vue
+++ b/portfolio/layouts/default.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <div class="absolute h-full">
+    <div class="absolute h-full w-full">
       <img
-        class="top-0"
+        class="w-full top-0"
         src="/images/bg.svg"
         width="1920"
         height="1080"


### PR DESCRIPTION
This pull request adds:
- Fix background vector width for width > `1920px`

Now, at `8192px`:
![image](https://user-images.githubusercontent.com/41923457/184549461-1adfeea0-c717-4c7e-8c2f-062a2cd266d4.png)
